### PR TITLE
Only open a file if `goto` was successful.

### DIFF
--- a/lib/import-js.js
+++ b/lib/import-js.js
@@ -133,7 +133,10 @@ function gotoWord() {
   withModuleFinder(() => {
     getImporter().goto(word)
       .then((result) => {
-        atom.open({ pathsToOpen: [result.goto], newWindow: false });
+
+        if (result.goto) {
+          atom.open({ pathsToOpen: [result.goto], newWindow: false });
+        }
 
         processResultMessages(result);
       })


### PR DESCRIPTION
This seems to be a simple fix for the issue where "goto" doesn't match anything but a new Atom window opens up anyway (which takes forever).

Closes #19 