### PR TITLE
Always open new tab in current workspace

### DIFF
--- a/lib/import-js.js
+++ b/lib/import-js.js
@@ -135,7 +135,7 @@ function gotoWord() {
       .then((result) => {
 
         if (result.goto) {
-          atom.open({ pathsToOpen: [result.goto], newWindow: false });
+          atom.workspace.open(result.goto);
         }
 
         processResultMessages(result);


### PR DESCRIPTION
I investigate the documentation for [atom.open()](https://atom.io/docs/api/v1.24.0/AtomEnvironment#instance-open) and concluded that this command is really for opening new windows. The flag `newWindow: false` merely suggests that Atom doesn't have to always open a new window.

In my own Atom scripts I have always used [atom.workspace.open()](https://atom.io/docs/api/v1.24.0/Workspace#instance-open), which will only open new tabs in current window/workspace.

Fixes #31